### PR TITLE
use closure instead of explicitly creating new environment

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,9 +1,0 @@
-Rs3tools.env <- new.env()
-.onLoad <- function(libname, pkgname) {
-  # S3 service
-  Rs3tools.env$s3 <- NULL
-  # Will credentials need reauthentication (i.e. not handled by paws)?
-  Rs3tools.env$temporary_authentication <- FALSE
-  # Expiration of current credentials, if needed
-  Rs3tools.env$authentication_expiry <- NULL
-}


### PR DESCRIPTION
This just builds on PR #20 but puts the environment in a different (possibly safer) place.

Although having thought about it more, I realise that we're still creating the `REGION` and `SESSIONDURATIONSECONDS` variables directly into the package's namespace, and so if someone did reference a variable with either of these names before creating their own versions in the Global Environment then they'll end up with unexpected results.  Not sure what best practise is here, but maybe we should just add these as default arguments to the function?  (We could also just remove the session duration one, and hard code it into the http request as I only added that to speed up testing.)